### PR TITLE
Fix code scanning alert no. 20: Use of a broken or weak cryptographic algorithm

### DIFF
--- a/tests/hazmat/primitives/test_ciphers.py
+++ b/tests/hazmat/primitives/test_ciphers.py
@@ -258,7 +258,8 @@ def test_update_auto_chunking():
     large_data = large_mmap(length=2**29 + 2**20)
 
     key = b"\x00" * 16
-    c = ciphers.Cipher(AES(key), modes.ECB())
+    iv = b"\x00" * 12
+    c = ciphers.Cipher(AES(key), modes.GCM(iv))
     encryptor = c.encryptor()
 
     result = encryptor.update(memoryview(large_data))


### PR DESCRIPTION
Fixes [https://github.com/fochoao-alt/cryptography/security/code-scanning/20](https://github.com/fochoao-alt/cryptography/security/code-scanning/20)

To fix the problem, we should replace the use of the insecure ECB mode with a more secure mode, such as GCM (Galois/Counter Mode). This change will ensure that the encryption is secure and follows modern cryptographic standards.

- Replace the `modes.ECB()` with `modes.GCM(b"\x00" * 12)` in the test function `test_update_auto_chunking`.
- Ensure that the key and IV sizes are appropriate for the chosen mode.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
