### PR TITLE
Fix code scanning alert no. 18: Use of a broken or weak cryptographic algorithm

### DIFF
--- a/tests/hazmat/primitives/test_ciphers.py
+++ b/tests/hazmat/primitives/test_ciphers.py
@@ -222,7 +222,8 @@ class TestCipherUpdateInto:
 
     def test_update_into_buffer_too_small(self, backend):
         key = b"\x00" * 16
-        c = ciphers.Cipher(AES(key), modes.ECB(), backend)
+        iv = os.urandom(12)
+        c = ciphers.Cipher(AES(key), modes.GCM(iv), backend)
         encryptor = c.encryptor()
         buf = bytearray(16)
         with pytest.raises(ValueError):
@@ -230,7 +231,8 @@ class TestCipherUpdateInto:
 
     def test_update_into_immutable(self, backend):
         key = b"\x00" * 16
-        c = ciphers.Cipher(AES(key), modes.ECB(), backend)
+        iv = os.urandom(12)
+        c = ciphers.Cipher(AES(key), modes.GCM(iv), backend)
         encryptor = c.encryptor()
         buf = b"\x00" * 32
         with pytest.raises((TypeError, BufferError)):


### PR DESCRIPTION
Fixes [https://github.com/fochoao-alt/cryptography/security/code-scanning/18](https://github.com/fochoao-alt/cryptography/security/code-scanning/18)

To fix the problem, we should replace the use of the insecure ECB mode with a more secure mode of operation. One suitable alternative is GCM (Galois/Counter Mode), which provides both confidentiality and integrity. This change will involve updating the mode of operation in the `ciphers.Cipher` instantiation.

- Replace `modes.ECB()` with `modes.GCM(iv)` where `iv` is a securely generated initialization vector.
- Ensure that the initialization vector (`iv`) is properly defined and used in the encryption and decryption processes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
